### PR TITLE
Mqtt driver patch

### DIFF
--- a/drivers/mqtt/home2l-drv-mqtt.C
+++ b/drivers/mqtt/home2l-drv-mqtt.C
@@ -445,7 +445,7 @@ class CMqttImport {
         }
         else
           vs->ToStr (&payload, false, false, false, INT_MAX);
-        mosqErr = mosquitto_publish (mosq, NULL, reqTopic.Get (), payload.Len () + 1, payload.Get (), envMqttQoS, true);
+        mosqErr = mosquitto_publish (mosq, NULL, reqTopic.Get (), payload.Len (), payload.Get (), envMqttQoS, true);
         if (mosqErr != MOSQ_ERR_SUCCESS)
           WARNINGF (("MQTT: Failed to publish '%s' <- '%s': %s", reqTopic.Get (), payload.Get (), mosquitto_strerror (mosqErr)));
         vs->SetToReportBusy ();
@@ -738,7 +738,7 @@ class CMqttExport: public CRcSubscriber {
         }
 
         // Publish ...
-        mosqErr = mosquitto_publish (mosq, NULL, _topic, payload[0] ? payload.Len () + 1 : 0, payload.Get (), envMqttQoS, true);
+        mosqErr = mosquitto_publish (mosq, NULL, _topic, payload[0] ? payload.Len () : 0, payload.Get (), envMqttQoS, true);
           // 'mid' = NULL (do not keep reference for later tracking), 'retain' = true
         if (mosqErr != MOSQ_ERR_SUCCESS)
           WARNINGF (("MQTT: Failed to publish '%s' = '%s': %s", _topic, payload.Get (), mosquitto_strerror (mosqErr)));
@@ -949,7 +949,7 @@ static void MqttCallbackOnConnect (struct mosquitto *mosq, void *, int connackCo
 
     // Publish birth ...
     if (!mqttBirthAndWillTopic.IsEmpty ()) {
-      mosqErr = mosquitto_publish (mosq, NULL, mqttBirthAndWillTopic.Get (), mqttBirthPayload.Len () + 1, mqttBirthPayload.Get (), envMqttQoS, true);
+      mosqErr = mosquitto_publish (mosq, NULL, mqttBirthAndWillTopic.Get (), mqttBirthPayload.Len (), mqttBirthPayload.Get (), envMqttQoS, true);
       if (mosqErr != MOSQ_ERR_SUCCESS)
         WARNINGF (("MQTT: Failed to set last will: %s", mosquitto_strerror (mosqErr)));
     }

--- a/drivers/mqtt/home2l-drv-mqtt.C
+++ b/drivers/mqtt/home2l-drv-mqtt.C
@@ -1065,11 +1065,11 @@ static void MqttInit () {
     mqttBirthAndWillTopic.Clear ();
   }
   else {
-    mqttWillPayload.SetC (args.Entries () <= 1 ? "0" : args[1]);
+    mqttWillPayload.SetF (args.Entries () <= 1 ? "0" : args[1]);
     mosqErr = mosquitto_will_set (mosq, mqttBirthAndWillTopic.Get (), mqttWillPayload.Len () + 1, mqttWillPayload.Get (), envMqttQoS, true);
     if (mosqErr != MOSQ_ERR_SUCCESS)
       WARNINGF (("MQTT: Failed to set last will: %s", mosquitto_strerror (mosqErr)));
-    mqttBirthPayload.SetC (args.Entries () <= 2 ? "1" : args[2]);
+    mqttBirthPayload.SetF (args.Entries () <= 2 ? "1" : args[2]);
   }
 
   // Start background thread ...


### PR DESCRIPTION
I found some bugs in the MQTT export driver:

**1. Bug**
Incorrect payload size for `mosquitto_publish` command, which will lead to encoding issues and not recognizable state and availability topics for external smart home systems like Home Assistant.
![Bild1](https://user-images.githubusercontent.com/120581904/226181725-59e5bfa7-7fef-444b-9809-88a64db4a5b4.png)
_Software: MQTT Explorer (0.4.0-beta1@Win10)_

**2. Bug**
custom settings like `mqtt.birthAndWill = status:offline:online` doesn't apply, because `SetC` is used instead of `SetF`

**3. Bug**
If you use two or more exported devices in the `home2l.conf`, only the first device will be exported.
**3.1** If you add a resource without a command topic (e.g. button @ brownie GPIO input) the empty/NULL entry will also added to `mqttSubList`.
My solution for the 3. bug is not a clean implementation, because it ignores empty/NULL entries in the `mqttSubList`.


&nbsp;
My configs on amd64 hardware to reproduce the issues:
-

**home2l.conf**
```
[daemon]
daemon.run.server = home2l-server 

[server]
rc.enableServer = 1
rc.serveInterface = local
rc.netTimeout     = 1000
rc.netRetryDelay  = 5000

[server]
drv.mqtt = 1
drv.brownies = 1

[server]
mqtt.broker = 192.168.178.5:1883
mqtt.username = home2l
mqtt.password = xxx
mqtt.birthAndWill = status:offline:online
mqtt.reqAttrs = *8

mqtt.export.led01 = /alias/led01::+/cmd:off:on
mqtt.export.led02 = /alias/led02::+/cmd:off:on
mqtt.export.led03 = /alias/led03::+/cmd:off:on
mqtt.export.led04 = /alias/led04::+/cmd:off:on
mqtt.export.led05 = /alias/led05::+/cmd:off:on
mqtt.export.led06 = /alias/led06::+/cmd:off:on
mqtt.export.led07 = /alias/led07::+/cmd:off:on
mqtt.export.led08 = /alias/led08::+/cmd:off:on
mqtt.export.led09 = /alias/led09::+/cmd:off:on
mqtt.export.led10 = /alias/led10::+/cmd:off:on

mqtt.export.button = /alias/button:::on:off

#mqtt.exportSet=/host/server/brownies/test1/gpio/1*

mqtt.import.mailbox = mailbox/state::mailbox/online=1::bool

[brownie2l,server]
br.serveSocket = brownies-drv
br.link = /dev/ttyUSB0

[brownie2l]
br.link = "="
```
&nbsp;

**Family.mk**
```
BROWNIE_FAMILY = init.t85 init.t84 init.t861 \
                 ahub.t85 bhub.t85 \
                 win.t84 win2.t84 wins.t84 \
                 gpio4.t84 \
                 mat4x8.t861 mat1x7.t861 mat2x6.t861 \
                 mat4x8t.t861 mat1x7t.t861 mat2x6t.t861 \
                 gpio5uart.t84 \
                 gatekeeper.t861 \
                 garage.t861 \
                 test1.t861

ifeq ($(BROWNIE_VARIANT),test1)
        BROWNIE_CFG ?= GPIO_IN_PRESENCE=0x1 GPIO_IN_PULLUP=0x1 GPIO_OUT_PRESENCE=0x7fe GPIO_OUT_PRESET=0x0
endif
....
```

&nbsp;
**brownie.conf**
```
008 id=test1 fw=test1 mcu=t861
```

&nbsp;

**resources.conf**
```
P 4700
H server      server@localhost:4701

A mailbox         /host/server/mqtt/mailbox

A button         /host/server/brownies/test1/gpio/00
A led01          /host/server/brownies/test1/gpio/01
A led02          /host/server/brownies/test1/gpio/02
A led03          /host/server/brownies/test1/gpio/03
A led04          /host/server/brownies/test1/gpio/04
A led05          /host/server/brownies/test1/gpio/05
A led06          /host/server/brownies/test1/gpio/06
A led07          /host/server/brownies/test1/gpio/07
A led08          /host/server/brownies/test1/gpio/08
A led09          /host/server/brownies/test1/gpio/09
A led10          /host/server/brownies/test1/gpio/10
```




